### PR TITLE
Fix DIGITS compilation error: `integer` is not a variable

### DIFF
--- a/quickutil-utilities/utilities/numbers.lisp
+++ b/quickutil-utilities/utilities/numbers.lisp
@@ -20,7 +20,7 @@ the following identity holds:
     (loop :with remainder
           :do (setf (values n remainder) (truncate n base))
           :collect remainder
-          :until (zerop integer)))
+          :until (zerop n)))
   %%%)
 
 ;;; Author: Goheeca (github: Goheeca)


### PR DESCRIPTION
Loops until `n` is 0, not `integer`.